### PR TITLE
Toggle default open state of Social Links and Projects sections

### DIFF
--- a/src/pages/Index.jsx
+++ b/src/pages/Index.jsx
@@ -103,7 +103,7 @@ const Index = () => {
   </p>
 </Box>
         </Box>
-        <CollapsibleSection title="Social Links" defaultOpen={false}>
+        <CollapsibleSection title="Social Links" defaultOpen={true}>
           <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={10}>
             <ProjectCard
               project={{
@@ -204,7 +204,7 @@ const Index = () => {
             />
           </SimpleGrid>
         </CollapsibleSection>
-        <CollapsibleSection title="My Open Source Projects" defaultOpen={true}>
+        <CollapsibleSection title="My Open Source Projects" defaultOpen={false}>
           <SimpleGrid columns={{ base: 1, md: 2, lg: 3 }} spacing={10}>
             {projects
               .filter(project => !project.name.includes("Contributor"))


### PR DESCRIPTION
## Summary
This PR swaps the default open/closed state of two collapsible sections on the Index page to improve the initial user experience and content visibility.

## Changes
- **Social Links section**: Changed `defaultOpen` from `false` to `true` - now expands by default on page load
- **My Open Source Projects section**: Changed `defaultOpen` from `true` to `false` - now collapses by default on page load

## Rationale
This adjustment prioritizes the Social Links section as the primary content visible to users when they first visit the page, while allowing the Open Source Projects section to be discovered through user interaction. This may improve initial page load perception and guide user attention to social connections first.

https://claude.ai/code/session_01WyiLHuVR8b561qheQqjGQj