### PR TITLE
Add llamafile to open source contributions

### DIFF
--- a/src/projects.json
+++ b/src/projects.json
@@ -147,6 +147,13 @@
     "live": "https://github.com/callstackincubator/voltra"
   },
   {
+    "name": "llamafile (Contributor)",
+    "description": "Distribute and run LLMs with a single executable file. llamafile packages llama.cpp with Cosmopolitan Libc so local AI models can run on multiple operating systems without installation or setup.",
+    "image": "https://opengraph.githubassets.com/1/Mozilla-Ocho/llamafile",
+    "github": "https://github.com/Mozilla-Ocho/llamafile",
+    "live": "https://github.com/Mozilla-Ocho/llamafile"
+  },
+  {
     "name": "Aider (Contributor)",
     "description": "AI pair programming in your terminal. Aider lets you pair program with LLMs to start a new project or build on your existing codebase, supporting 100+ programming languages and multiple LLM providers.",
     "image": "https://opengraph.githubassets.com/1/aider-chat/aider",


### PR DESCRIPTION
### Motivation
- Add `llamafile` to the project's list of open source contributions so the site reflects contributions to the project that packages `llama.cpp` with Cosmopolitan Libc for portable local LLM execution.

### Description
- Inserted a new `llamafile (Contributor)` entry into `src/projects.json` containing a short description, OpenGraph image URL, `github` and `live` links.

### Testing
- Validated `src/projects.json` with `node -e "JSON.parse(require('fs').readFileSync('src/projects.json','utf8')); console.log('valid json')"` and ran a production build with `npm run build`, both of which succeeded; an attempted Playwright browser install for a screenshot failed due to CDN `403` responses.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28ff9a5bac833093de2cfd22bbd561)