### PR TITLE
Add Hermes Agent to Open Source Contributions

### DIFF
--- a/src/projects.json
+++ b/src/projects.json
@@ -105,6 +105,13 @@
     "live": "https://agent-battler.vercel.app"
   },
   {
+    "name": "Hermes Agent (Contributor)",
+    "description": "A self-improving AI agent from Nous Research with a built-in learning loop. Creates and improves skills from experience, remembers context across sessions, supports multiple messaging platforms, scheduled automations, subagents, and flexible model providers.",
+    "image": "https://opengraph.githubassets.com/1/NousResearch/hermes-agent",
+    "github": "https://github.com/NousResearch/hermes-agent",
+    "live": "https://hermes-agent.nousresearch.com"
+  },
+  {
     "name": "OpenClaw (Contributor)",
     "description": "Your own personal AI assistant. Any OS. Any Platform. A local-first AI assistant that connects to multiple messaging platforms (WhatsApp, Telegram, Slack, Discord) and provides a gateway control plane for managing sessions, channels, and tools.",
     "image": "https://opengraph.githubassets.com/1/openclaw/openclaw",


### PR DESCRIPTION
### Motivation
- Surface the `Hermes Agent` project in the website's Open Source Contributions list so contributions to Nous Research's agent are visible on the projects page.

### Description
- Added a new contributor entry for "Hermes Agent (Contributor)" to `src/projects.json` with `name`, `description`, `image` (OpenGraph), `github`, and `live` fields. 
- The entry was inserted into the existing contributions section so it appears alongside other "(Contributor)" projects in the site UI.

### Testing
- Ran `npm run build` which completed successfully and produced the production `dist` output. 
- Started the dev server via `npm run dev` which reported the local server ready and served the site. 
- Attempted to run `npx playwright install chromium` to capture a UI screenshot, but the Playwright browser download failed with HTTP 403 so browser-driven verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b4e9687548330ac28bbdc835ae989)